### PR TITLE
Fix getMarkerData bug.

### DIFF
--- a/build/player/lottie.js
+++ b/build/player/lottie.js
@@ -13300,7 +13300,7 @@ AnimationItem.prototype.getMarkerData = function (markerName) {
   var marker;
   for (var i = 0; i < this.markers.length; i += 1) {
     marker = this.markers[i];
-    if (marker.payload && marker.payload.name === markerName) {
+    if (marker.payload && marker.payload.name.cm === markerName) {
       return marker;
     }
   }


### PR DESCRIPTION
Add `.cm` to match the correct marker name as marker object has this structure: 
`"markers":[{"tm":0,"cm":"clickActivate","dr":100}]` with `cm` for marker's name.